### PR TITLE
Update Build-gradle-microservice-container.yaml

### DIFF
--- a/.github/workflows/Build-gradle-microservice-container.yaml
+++ b/.github/workflows/Build-gradle-microservice-container.yaml
@@ -154,7 +154,7 @@ jobs:
         echo "CONTAINER_TAG=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_ENV        
 
     - name: Scan container image
-      continue-on-error: true      
+      continue-on-error: false      
       uses: CDCgov/NEDSS-Workflows/.github/actions/trivy-scanner@main
       with:
         container-ref: ${{ env.CONTAINER_TAG }}


### PR DESCRIPTION
enable make jobs fail if Trivy scan fails