### PR TITLE
feat: add support to push releases to octopus

### DIFF
--- a/.github/workflows/Build-gradle-microservice-container.yaml
+++ b/.github/workflows/Build-gradle-microservice-container.yaml
@@ -67,7 +67,7 @@ on:
         type: string
       # Octopus Deploy inputs
       create_octopus_release:
-        description: "Create an Octopus Deploy release after successfully pushing to ECR. If false, it will still default to true on the main branch if octopus_project or microservice_name is provided."
+        description: "Create an Octopus Deploy release after successfully pushing to ECR. Even if false, it will still default to true on the main branch."
         required: false
         default: false
         type: boolean

--- a/.github/workflows/Build-gradle-microservice-container.yaml
+++ b/.github/workflows/Build-gradle-microservice-container.yaml
@@ -211,6 +211,7 @@ jobs:
       with:
         repository: CDCgov/NEDSS-Workflows
         path: .workflows-repo
+        ref: cm/octopus
 
     - name: Resolve Octopus Project and Package
       id: resolve

--- a/.github/workflows/Build-gradle-microservice-container.yaml
+++ b/.github/workflows/Build-gradle-microservice-container.yaml
@@ -210,14 +210,19 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: CDCgov/NEDSS-Workflows
-        path: .workflows-repo
+        path: workflows-repo
         ref: cm/octopus
+
+    - name: Debug - List files
+      run: |
+        echo "Current PWD: $(pwd)"
+        ls -R workflows-repo
 
     - name: Resolve Octopus Project and Package
       id: resolve
       shell: bash
       run: |
-        MAPPING_FILE=".workflows-repo/octopus-mapping.yaml"
+        MAPPING_FILE="workflows-repo/octopus-mapping.yaml"
         SERVICE_NAME="${{ inputs.microservice_name }}"
         
         # Check if the service name exists in the mapping file

--- a/.github/workflows/Build-gradle-microservice-container.yaml
+++ b/.github/workflows/Build-gradle-microservice-container.yaml
@@ -67,12 +67,12 @@ on:
         type: string
       # Octopus Deploy inputs
       create_octopus_release:
-        description: "Create an Octopus Deploy release after successfully pushing to ECR. Requires octopus_project input and OCTOPUS_API_KEY secret."
+        description: "Create an Octopus Deploy release after successfully pushing to ECR. If false, it will still default to true on the main branch if octopus_project or microservice_name is provided."
         required: false
         default: false
         type: boolean
       octopus_project:
-        description: "Octopus Deploy project name to create a release for. Required if create_octopus_release is true."
+        description: "Octopus Deploy project name to create a release for. Defaults to microservice_name if not provided."
         required: false
         type: string
       octopus_channel:
@@ -97,8 +97,11 @@ on:
         type: string
     secrets:
       NBS_ACCOUNTID:
-        description: "Secret named NBS_ACCOUNTID where ECR resides."
-        required: true
+        description: "AWS Account ID where ECR resides."
+        required: false
+      CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID:
+        description: "Backward compatible AWS Account ID where ECR resides."
+        required: false
     outputs:
       output_image_tag:
         description: "Container image tag"
@@ -151,7 +154,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: "arn:aws:iam::${{ secrets.NBS_ACCOUNTID }}:role/github-actions-nbs-deployment-role"
+        role-to-assume: "arn:aws:iam::${{ secrets.NBS_ACCOUNTID || secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID }}:role/github-actions-nbs-deployment-role"
         role-session-name: deploy-infrastructure
         aws-region: us-east-2
 
@@ -200,13 +203,52 @@ jobs:
   create-octopus-release:
     name: Create Octopus Release
     needs: build
-    if: ${{ inputs.create_octopus_release == true && inputs.octopus_project != '' && (inputs.octopus_api_key_secret_name != '' || vars.AWS_OCTOPUS_API_KEY_ARN != '') }}
+    if: ${{ (inputs.create_octopus_release == true || github.ref == 'refs/heads/main') && (inputs.octopus_api_key_secret_name != '' || vars.AWS_OCTOPUS_API_KEY_ARN != '') }}
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout NEDSS-Workflows (for mapping)
+      uses: actions/checkout@v4
+      with:
+        repository: CDCgov/NEDSS-Workflows
+        path: .workflows-repo
+
+    - name: Resolve Octopus Project and Package
+      id: resolve
+      shell: bash
+      run: |
+        MAPPING_FILE=".workflows-repo/octopus-mapping.yaml"
+        SERVICE_NAME="${{ inputs.microservice_name }}"
+        
+        # Check if the service name exists in the mapping file
+        # yq returns 'null' if the key doesn't exist
+        VAL=$(yq ".mappings.\"$SERVICE_NAME\"" $MAPPING_FILE)
+        
+        if [ "$VAL" == "null" ]; then
+          # Fallback if no mapping exists
+          PROJECT_NAME="${{ inputs.octopus_project || inputs.microservice_name }}"
+          PACKAGE_ID="${{ inputs.microservice_name }}"
+        elif [[ "$VAL" == *"project:"* ]]; then
+          # Complex mapping (object with project/package)
+          PROJECT_NAME=$(yq ".mappings.\"$SERVICE_NAME\".project" $MAPPING_FILE)
+          PACKAGE_ID=$(yq ".mappings.\"$SERVICE_NAME\".package" $MAPPING_FILE)
+        else
+          # Simple mapping (direct string)
+          PROJECT_NAME="$VAL"
+          PACKAGE_ID="${{ inputs.microservice_name }}"
+        fi
+        
+        # Override project name if explicitly provided via input
+        if [ -n "${{ inputs.octopus_project }}" ]; then
+          PROJECT_NAME="${{ inputs.octopus_project }}"
+        fi
+
+        echo "project_name=$PROJECT_NAME" >> $GITHUB_OUTPUT
+        echo "package_id=$PACKAGE_ID" >> $GITHUB_OUTPUT
+
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: "arn:aws:iam::${{ secrets.NBS_ACCOUNTID }}:role/github-actions-nbs-deployment-role"
+        role-to-assume: "arn:aws:iam::${{ secrets.NBS_ACCOUNTID || secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID }}:role/github-actions-nbs-deployment-role"
         role-session-name: octopus-release
         aws-region: us-east-2
 
@@ -226,8 +268,8 @@ jobs:
         OCTOPUS_URL: ${{ inputs.octopus_server_url }}
         OCTOPUS_SPACE: ${{ inputs.octopus_space }}
       with:
-        project: ${{ inputs.octopus_project }}
+        project: ${{ steps.resolve.outputs.project_name }}
         channel: ${{ inputs.octopus_channel }}
         release_number: ${{ needs.build.outputs.output_image_tag }}
-        packages: "${{ inputs.microservice_name }}:${{ needs.build.outputs.output_image_tag }}"
+        packages: "${{ steps.resolve.outputs.package_id }}:${{ needs.build.outputs.output_image_tag }}"
         ignore_existing: true

--- a/.github/workflows/Build-gradle-microservice-container.yaml
+++ b/.github/workflows/Build-gradle-microservice-container.yaml
@@ -20,15 +20,15 @@ on:
         required: false
         default: '17'
         type: string
-      # Container scanning inputs   
+      # Container scanning inputs
       severity:
         description: 'Severities of vulnerabilities to be scanned for and displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL)'
-        required: false  
+        required: false
         default: 'CRITICAL,HIGH'
         type: string
       limit-severities-for-sarif:
         description: 'By default SARIF format enforces output of all vulnerabilities regardless of configured severities. To override this behavior set this parameter to true'
-        required: false  
+        required: false
         default: true
         type: boolean
       upload-to-github-security-tab:
@@ -40,38 +40,68 @@ on:
         description: Ignore unpatched/unfixed vulnerabilities
         required: false
         default: false
-        type: boolean 
+        type: boolean
       skip-dirs:
         description: 'Comma separated list of directories where traversal is skipped'
-        required: false 
+        required: false
         default: ''
         type: string
       skip-files:
         description: 'Comma separated list of files where traversal is skipped'
-        required: false  
+        required: false
         default: ''
         type: string
       timeout:
         description: 'Scan timeout duration'
-        required: false  
+        required: false
         default: '10m0s'
         type: string
       exit-code:
         description: 'Exit code when specified vulnerabilities are found (0).'
-        required: false  
+        required: false
         default: '0'
         type: string
       trivyignores:
         description: 'Comma-separated list of relative paths in repository to one or more .trivyignore files, for usage see https://aquasecurity.github.io/trivy/v0.19.2/vulnerability/examples/filter/'
-        required: false         
-        type: string        
+        required: false
+        type: string
+      # Octopus Deploy inputs
+      create_octopus_release:
+        description: "Create an Octopus Deploy release after successfully pushing to ECR. Requires octopus_project input and OCTOPUS_API_KEY secret."
+        required: false
+        default: false
+        type: boolean
+      octopus_project:
+        description: "Octopus Deploy project name to create a release for. Required if create_octopus_release is true."
+        required: false
+        type: string
+      octopus_channel:
+        description: "Octopus Deploy release channel."
+        required: false
+        default: 'alpha-main'
+        type: string
+      octopus_space:
+        description: "Octopus Deploy space name."
+        required: false
+        default: 'Default'
+        type: string
+      octopus_server_url:
+        description: "Octopus Deploy server URL."
+        required: false
+        default: 'https://octopus.skylightnbs.com'
+        type: string
+      octopus_api_key_secret_name:
+        description: "Name or ARN of the AWS Secrets Manager secret holding the Octopus Deploy API key. Defaults to the AWS_OCTOPUS_API_KEY_ARN repo/org variable if not provided."
+        required: false
+        default: ''
+        type: string
     secrets:
       NBS_ACCOUNTID:
         description: "Secret named NBS_ACCOUNTID where ECR resides."
         required: true
     outputs:
       output_image_tag:
-        description: "Container image tag" 
+        description: "Container image tag"
         value: ${{ jobs.build.outputs.output_image_tag }}
 jobs:
   build:
@@ -97,15 +127,15 @@ jobs:
         distribution: 'temurin'
         java-version: ${{ inputs.java_version }}
         cache: 'gradle'
-    
+
     - name: Configure Environment Variables
       run: |
-        github_sha_short=$(git rev-parse --short "$GITHUB_SHA")      
-        github_repo_name="$(echo $GITHUB_REPOSITORY | cut -d'/' -f2)"        
+        github_sha_short=$(git rev-parse --short "$GITHUB_SHA")
+        github_repo_name="$(echo $GITHUB_REPOSITORY | cut -d'/' -f2)"
         github_tag=${GITHUB_REF#refs/tags/}
-        echo "github_sha_short=$github_sha_short" >> $GITHUB_ENV        
+        echo "github_sha_short=$github_sha_short" >> $GITHUB_ENV
         echo "github_tag=$github_tag" >> $GITHUB_ENV
-        echo "github_repo_name=$github_repo_name" >> $GITHUB_ENV      
+        echo "github_repo_name=$github_repo_name" >> $GITHUB_ENV
 
     - name: (Gradle) Create microservice version tag
       run: |
@@ -136,13 +166,13 @@ jobs:
         ECR_REPOSITORY: ${{ inputs.microservice_name }}
         IMAGE_TAG: "${{ env.new_image_tag }}"
       run: |
-        # Build a docker container 
-        echo "Building image.." 
+        # Build a docker container
+        echo "Building image.."
         docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG ${{ inputs.dockerfile_relative_path}}
-        echo "CONTAINER_TAG=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_ENV        
+        echo "CONTAINER_TAG=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_ENV
 
     - name: Scan container image
-      continue-on-error: false      
+      continue-on-error: false
       uses: CDCgov/NEDSS-Workflows/.github/actions/trivy-scanner@main
       with:
         container-ref: ${{ env.CONTAINER_TAG }}
@@ -166,3 +196,38 @@ jobs:
         echo "Pushing image to ECR..."
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+  create-octopus-release:
+    name: Create Octopus Release
+    needs: build
+    if: ${{ inputs.create_octopus_release == true && inputs.octopus_project != '' && (inputs.octopus_api_key_secret_name != '' || vars.AWS_OCTOPUS_API_KEY_ARN != '') }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: "arn:aws:iam::${{ secrets.NBS_ACCOUNTID }}:role/github-actions-nbs-deployment-role"
+        role-session-name: octopus-release
+        aws-region: us-east-2
+
+    - name: Retrieve Octopus API key from AWS Secrets Manager
+      run: |
+        secret=$(aws secretsmanager get-secret-value \
+          --secret-id "${{ inputs.octopus_api_key_secret_name || vars.AWS_OCTOPUS_API_KEY_ARN }}" \
+          --query SecretString \
+          --output text)
+        echo "::add-mask::$secret"
+        echo "OCTOPUS_API_KEY=$secret" >> $GITHUB_ENV
+
+    - name: Create a release in Octopus Deploy
+      uses: OctopusDeploy/create-release-action@v4
+      env:
+        OCTOPUS_API_KEY: ${{ env.OCTOPUS_API_KEY }}
+        OCTOPUS_URL: ${{ inputs.octopus_server_url }}
+        OCTOPUS_SPACE: ${{ inputs.octopus_space }}
+      with:
+        project: ${{ inputs.octopus_project }}
+        channel: ${{ inputs.octopus_channel }}
+        release_number: ${{ needs.build.outputs.output_image_tag }}
+        packages: "${{ inputs.microservice_name }}:${{ needs.build.outputs.output_image_tag }}"
+        ignore_existing: true

--- a/.github/workflows/Build-other-microservice-container.yaml
+++ b/.github/workflows/Build-other-microservice-container.yaml
@@ -58,15 +58,48 @@ on:
         type: string
       trivyignores:
         description: 'Comma-separated list of relative paths in repository to one or more .trivyignore files, for usage see https://aquasecurity.github.io/trivy/v0.19.2/vulnerability/examples/filter/'
-        required: false         
-        type: string   
+        required: false
+        type: string
+      # Octopus Deploy inputs
+      create_octopus_release:
+        description: "Create an Octopus Deploy release after successfully pushing to ECR. If false, it will still default to true on the main branch if octopus_project or microservice_name is provided."
+        required: false
+        default: false
+        type: boolean
+      octopus_project:
+        description: "Octopus Deploy project name to create a release for. Defaults to microservice_name if not provided."
+        required: false
+        type: string
+      octopus_channel:
+        description: "Octopus Deploy release channel."
+        required: false
+        default: 'alpha-main'
+        type: string
+      octopus_space:
+        description: "Octopus Deploy space name."
+        required: false
+        default: 'Default'
+        type: string
+      octopus_server_url:
+        description: "Octopus Deploy server URL."
+        required: false
+        default: 'https://octopus.skylightnbs.com'
+        type: string
+      octopus_api_key_secret_name:
+        description: "Name or ARN of the AWS Secrets Manager secret holding the Octopus Deploy API key. Defaults to the AWS_OCTOPUS_API_KEY_ARN repo/org variable if not provided."
+        required: false
+        default: ''
+        type: string
     secrets:
       NBS_ACCOUNTID:
-        description: "Secret named NBS_ACCOUNTID where ECR resides."
-        required: true
+        description: "AWS Account ID where ECR resides."
+        required: false
+      CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID:
+        description: "Backward compatible AWS Account ID where ECR resides."
+        required: false
     outputs:
       output_image_tag:
-        description: "Container image tag" 
+        description: "Container image tag"
         value: ${{ jobs.build.outputs.output_image_tag }}
 
 jobs:
@@ -86,15 +119,15 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    
+
     - name: Configure Environment Variables
       run: |
-        github_sha_short=$(git rev-parse --short "$GITHUB_SHA")      
-        github_repo_name="$(echo $GITHUB_REPOSITORY | cut -d'/' -f2)"        
+        github_sha_short=$(git rev-parse --short "$GITHUB_SHA")
+        github_repo_name="$(echo $GITHUB_REPOSITORY | cut -d'/' -f2)"
         github_tag=${GITHUB_REF#refs/tags/}
-        echo "github_sha_short=$github_sha_short" >> $GITHUB_ENV        
+        echo "github_sha_short=$github_sha_short" >> $GITHUB_ENV
         echo "github_tag=$github_tag" >> $GITHUB_ENV
-        echo "github_repo_name=$github_repo_name" >> $GITHUB_ENV        
+        echo "github_repo_name=$github_repo_name" >> $GITHUB_ENV
 
     - name: (Other) Create microservice version tag from dockerfile image name
       run: |
@@ -110,7 +143,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: "arn:aws:iam::${{ secrets.NBS_ACCOUNTID }}:role/github-actions-nbs-deployment-role"
+        role-to-assume: "arn:aws:iam::${{ secrets.NBS_ACCOUNTID || secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID }}:role/github-actions-nbs-deployment-role"
         role-session-name: deploy-infrastructure
         aws-region: us-east-2
 
@@ -118,7 +151,7 @@ jobs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v2
 
-    - name: Build and tag ${{ inputs.microservice_name }} image 
+    - name: Build and tag ${{ inputs.microservice_name }} image
       id: build-image
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -126,12 +159,12 @@ jobs:
         IMAGE_TAG: "${{ env.new_image_tag }}"
       run: |
         # Build a docker container
-        echo "Building image.." 
+        echo "Building image.."
         docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG ${{ inputs.dockerfile_relative_path}}
         echo "CONTAINER_TAG=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_ENV
-      
-    - name: Scan container image 
-      continue-on-error: true      
+
+    - name: Scan container image
+      continue-on-error: true
       uses: CDCgov/NEDSS-Workflows/.github/actions/trivy-scanner@main
       with:
         container-ref: ${{ env.CONTAINER_TAG }}
@@ -143,7 +176,7 @@ jobs:
         exit-code: ${{ inputs.exit-code }}
         trivyignores: ${{ inputs.trivyignores }}
         limit-severities-for-sarif: ${{inputs.limit-severities-for-sarif}}
-       
+
     - name: Push ${{ inputs.microservice_name }} image to Amazon ECR
       if: ${{ !cancelled() }}
       id: push-image
@@ -155,4 +188,78 @@ jobs:
         echo "Pushing image to ECR..."
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+  create-octopus-release:
+    name: Create Octopus Release
+    needs: build
+    if: ${{ (inputs.create_octopus_release == true || github.ref == 'refs/heads/main') && (inputs.octopus_api_key_secret_name != '' || vars.AWS_OCTOPUS_API_KEY_ARN != '') }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout NEDSS-Workflows (for mapping)
+      uses: actions/checkout@v4
+      with:
+        repository: CDCgov/NEDSS-Workflows
+        path: .workflows-repo
+
+    - name: Resolve Octopus Project and Package
+      id: resolve
+      shell: bash
+      run: |
+        MAPPING_FILE=".workflows-repo/octopus-mapping.yaml"
+        SERVICE_NAME="${{ inputs.microservice_name }}"
+        
+        # Check if the service name exists in the mapping file
+        # yq returns 'null' if the key doesn't exist
+        VAL=$(yq ".mappings.\"$SERVICE_NAME\"" $MAPPING_FILE)
+        
+        if [ "$VAL" == "null" ]; then
+          # Fallback if no mapping exists
+          PROJECT_NAME="${{ inputs.octopus_project || inputs.microservice_name }}"
+          PACKAGE_ID="${{ inputs.microservice_name }}"
+        elif [[ "$VAL" == *"project:"* ]]; then
+          # Complex mapping (object with project/package)
+          PROJECT_NAME=$(yq ".mappings.\"$SERVICE_NAME\".project" $MAPPING_FILE)
+          PACKAGE_ID=$(yq ".mappings.\"$SERVICE_NAME\".package" $MAPPING_FILE)
+        else
+          # Simple mapping (direct string)
+          PROJECT_NAME="$VAL"
+          PACKAGE_ID="${{ inputs.microservice_name }}"
+        fi
+        
+        # Override project name if explicitly provided via input
+        if [ -n "${{ inputs.octopus_project }}" ]; then
+          PROJECT_NAME="${{ inputs.octopus_project }}"
+        fi
+
+        echo "project_name=$PROJECT_NAME" >> $GITHUB_OUTPUT
+        echo "package_id=$PACKAGE_ID" >> $GITHUB_OUTPUT
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: "arn:aws:iam::${{ secrets.NBS_ACCOUNTID || secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID }}:role/github-actions-nbs-deployment-role"
+        role-session-name: octopus-release
+        aws-region: us-east-2
+
+    - name: Retrieve Octopus API key from AWS Secrets Manager
+      run: |
+        secret=$(aws secretsmanager get-secret-value \
+          --secret-id "${{ inputs.octopus_api_key_secret_name || vars.AWS_OCTOPUS_API_KEY_ARN }}" \
+          --query SecretString \
+          --output text)
+        echo "::add-mask::$secret"
+        echo "OCTOPUS_API_KEY=$secret" >> $GITHUB_ENV
+
+    - name: Create a release in Octopus Deploy
+      uses: OctopusDeploy/create-release-action@v4
+      env:
+        OCTOPUS_API_KEY: ${{ env.OCTOPUS_API_KEY }}
+        OCTOPUS_URL: ${{ inputs.octopus_server_url }}
+        OCTOPUS_SPACE: ${{ inputs.octopus_space }}
+      with:
+        project: ${{ steps.resolve.outputs.project_name }}
+        channel: ${{ inputs.octopus_channel }}
+        release_number: ${{ needs.build.outputs.output_image_tag }}
+        packages: "${{ steps.resolve.outputs.package_id }}:${{ needs.build.outputs.output_image_tag }}"
+        ignore_existing: true
 

--- a/.github/workflows/Release-gradle-microservice-container.yaml
+++ b/.github/workflows/Release-gradle-microservice-container.yaml
@@ -77,7 +77,7 @@ on:
     secrets:
       CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID:
         description: "Secret named CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID where ECR resides."
-        required: true
+        required: false
       ECR_REPO_BASE_NAME:
         description: "Secret named ECR_REPO_BASE_NAME describing the ECR base path name."
         required: true
@@ -89,6 +89,9 @@ on:
         required: false
       HELM_TOKEN:
         description: "Secret named HELM_TOKEN to access helm chart repository"
+        required: false
+      NBS_ACCOUNTID:
+        description: "AWS Account ID where ECR resides."
         required: false
     outputs:
       output_image_tag:
@@ -152,7 +155,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: "arn:aws:iam::${{ secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID }}:role/github-actions-nbs-deployment-role"
+        role-to-assume: "arn:aws:iam::${{ secrets.NBS_ACCOUNTID || secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID }}:role/github-actions-nbs-deployment-role"
         role-session-name: tag-containers
         aws-region: us-east-2
 
@@ -215,3 +218,67 @@ jobs:
         echo "Pushing image to ECR..."
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT  
+
+  create-octopus-release:
+    name: Create Octopus Release
+    needs: deploy
+    if: ${{ github.ref == 'refs/heads/main' && vars.AWS_OCTOPUS_API_KEY_ARN != '' }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout NEDSS-Workflows (for mapping)
+      uses: actions/checkout@v4
+      with:
+        repository: CDCgov/NEDSS-Workflows
+        path: .workflows-repo
+
+    - name: Resolve Octopus Project and Package
+      id: resolve
+      shell: bash
+      run: |
+        MAPPING_FILE=".workflows-repo/octopus-mapping.yaml"
+        SERVICE_NAME="${{ inputs.microservice_name }}"
+        
+        VAL=$(yq ".mappings.\"$SERVICE_NAME\"" $MAPPING_FILE)
+        
+        if [ "$VAL" == "null" ]; then
+          PROJECT_NAME="${{ inputs.microservice_name }}"
+          PACKAGE_ID="${{ inputs.microservice_name }}"
+        elif [[ "$VAL" == *"project:"* ]]; then
+          PROJECT_NAME=$(yq ".mappings.\"$SERVICE_NAME\".project" $MAPPING_FILE)
+          PACKAGE_ID=$(yq ".mappings.\"$SERVICE_NAME\".package" $MAPPING_FILE)
+        else
+          PROJECT_NAME="$VAL"
+          PACKAGE_ID="${{ inputs.microservice_name }}"
+        fi
+        
+        echo "project_name=$PROJECT_NAME" >> $GITHUB_OUTPUT
+        echo "package_id=$PACKAGE_ID" >> $GITHUB_OUTPUT
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: "arn:aws:iam::${{ secrets.NBS_ACCOUNTID || secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID }}:role/github-actions-nbs-deployment-role"
+        role-session-name: octopus-release
+        aws-region: us-east-2
+
+    - name: Retrieve Octopus API key from AWS Secrets Manager
+      run: |
+        secret=$(aws secretsmanager get-secret-value \
+          --secret-id "${{ vars.AWS_OCTOPUS_API_KEY_ARN }}" \
+          --query SecretString \
+          --output text)
+        echo "::add-mask::$secret"
+        echo "OCTOPUS_API_KEY=$secret" >> $GITHUB_ENV
+
+    - name: Create a release in Octopus Deploy
+      uses: OctopusDeploy/create-release-action@v4
+      env:
+        OCTOPUS_API_KEY: ${{ env.OCTOPUS_API_KEY }}
+        OCTOPUS_URL: 'https://octopus.skylightnbs.com'
+        OCTOPUS_SPACE: 'Default'
+      with:
+        project: ${{ steps.resolve.outputs.project_name }}
+        channel: 'alpha-main'
+        release_number: ${{ needs.deploy.outputs.output_image_tag }}
+        packages: "${{ steps.resolve.outputs.package_id }}:${{ needs.deploy.outputs.output_image_tag }}"
+        ignore_existing: true

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # NEDSS Reusable Workflows and custom GitHub actions
 ## Overview
-This repository is a central location for managing reusable workflows to be used in microservices developed as a part of the NBS modernization project for consistent CI/CD processes. GitHub Actions is the tool used to create these workflows which are intended to be adopted by any team who needs any of the services provided below. 
+This repository is a central location for managing reusable workflows to be used in microservices developed as a part of the NBS modernization project for consistent CI/CD processes. GitHub Actions is the tool used to create these workflows which are intended to be adopted by any team who needs any of the services provided below.
 
 ## Prerequisites for container related workflows
 1. Request your repository be granted access to the environment containing the Elastic Container Registry (ECR).
 2. Request and received confirmation that an ECR was created to store your artifact (microservice container image).
 
 ## Usage
-Reusable workflows are meant to be easily picked up and placed in your repositories CI/CD pipeline. To further this effort [sample_templates](./sample_templates/) are provided. 
+Reusable workflows are meant to be easily picked up and placed in your repositories CI/CD pipeline. To further this effort [sample_templates](./sample_templates/) are provided.
 1. [Sample-call-build-and-deploy-workflow.yaml](./sample_templates/Sample-call-build-and-deploy-workflow.yaml) - this workflow is intended to be used when container images need to be built. It promotes automated deployment by modifiying a helm charts values.yaml file.
   - Note 1: This is a general template and a full list of variables can be found below.
   - Note 2: This template only references Build-other-microservice-container.yaml and the `uses` line for the call-build-microservice-container-workflow job should be changed to reflect the intended reusuable workflow.
@@ -61,6 +61,12 @@ This workflow build a container and push it to ECR. Application versioning is ob
 | timeout | string | '10m0s' | 'Scan timeout duration' | false |
 | trivyignores | string |  | 'Comma-separated list of relative paths in repository to one or more .trivyignore files, for usage see https://aquasecurity.github.io/trivy/v0.19.2/vulnerability/examples/filter/' | false |
 | upload-to-github-security-tab | boolean | true | 'Upload results to GitHub security tab?' | false |
+| create_octopus_release | boolean | false | Create an Octopus Deploy release after successfully pushing to ECR. Requires `octopus_project` and either `octopus_api_key_secret_name` or the `AWS_OCTOPUS_API_KEY_ARN` org/repo variable to be set. | false |
+| octopus_project | string | | Octopus Deploy project name to create a release for. Required if `create_octopus_release` is true. | false |
+| octopus_channel | string | 'alpha-main' | Octopus Deploy release channel. | false |
+| octopus_space | string | 'Default' | Octopus Deploy space name. | false |
+| octopus_server_url | string | 'https://octopus.skylightnbs.com' | Octopus Deploy server URL. | false |
+| octopus_api_key_secret_name | string | | Name or ARN of the AWS Secrets Manager secret holding the Octopus Deploy API key. Defaults to the `AWS_OCTOPUS_API_KEY_ARN` org/repo variable if not provided. | false |
 
 #### Input Secrets
 | Key | Type | Default | Description | Required |
@@ -75,6 +81,32 @@ This workflow build a container and push it to ECR. Application versioning is ob
 | Key | Type | Description |
 | -------------- | -------------- | -------------- |
 | output_image_tag | string | "Container image tag"  |
+
+#### Octopus Deploy Release Creation
+When `create_octopus_release` is enabled, a release is automatically created in Octopus Deploy after a successful ECR push. The Octopus API key is retrieved from AWS Secrets Manager using the same IAM role used for ECR — no additional GitHub secrets are required.
+
+**Prerequisites:**
+- The `AWS_OCTOPUS_API_KEY_ARN` variable must be set at the org or repo level (or passed via `octopus_api_key_secret_name`).
+- The `github-actions-nbs-deployment-role` IAM role must have `secretsmanager:GetSecretValue` permission on the API key secret.
+
+**Example — calling workflow in a downstream repo:**
+```yaml
+jobs:
+  build:
+    uses: CDCgov/NEDSS-Workflows/.github/workflows/Build-gradle-microservice-container.yaml@main
+    with:
+      microservice_name: my-service
+      dockerfile_relative_path: Dockerfile
+      environment_classifier: SNAPSHOT
+      create_octopus_release: true
+      octopus_project: 'My Octopus Project'   # must match the project name in Octopus exactly
+      # octopus_channel defaults to 'alpha-main'
+      # octopus_space defaults to 'Default'
+    secrets:
+      NBS_ACCOUNTID: ${{ secrets.NBS_ACCOUNTID }}
+```
+
+The release number in Octopus will match the ECR image tag (e.g. `1.0.0-SNAPSHOT.abc1234`), giving full traceability between the Octopus release, the container image, and the git commit.
 
 ### [Build-other-microservice-container.yaml](./workflows/Build-other-microservice-container.yaml)
 This workflow build a container and push it to ECR. Application versioning is obtained using from the dockerfile after the initial `FROM` block (e.g. `FROM elasticsearch:v1.0.0` results in `v1.0.0`). Uses [Trivy-Scanner](.github/actions/trivy-scanner/action.yaml) for container scanning.

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ This workflow build a container and push it to ECR. Application versioning is ob
 | timeout | string | '10m0s' | 'Scan timeout duration' | false |
 | trivyignores | string |  | 'Comma-separated list of relative paths in repository to one or more .trivyignore files, for usage see https://aquasecurity.github.io/trivy/v0.19.2/vulnerability/examples/filter/' | false |
 | upload-to-github-security-tab | boolean | true | 'Upload results to GitHub security tab?' | false |
-| create_octopus_release | boolean | false | Create an Octopus Deploy release after successfully pushing to ECR. Requires `octopus_project` and either `octopus_api_key_secret_name` or the `AWS_OCTOPUS_API_KEY_ARN` org/repo variable to be set. | false |
-| octopus_project | string | | Octopus Deploy project name to create a release for. Required if `create_octopus_release` is true. | false |
+| create_octopus_release | boolean | false | Create an Octopus Deploy release after successfully pushing to ECR. If false, it will still default to true on the main branch if the Octopus API key ARN is available. | false |
+| octopus_project | string | | Octopus Deploy project name to create a release for. Defaults to `microservice_name` if not provided. | false |
 | octopus_channel | string | 'alpha-main' | Octopus Deploy release channel. | false |
 | octopus_space | string | 'Default' | Octopus Deploy space name. | false |
 | octopus_server_url | string | 'https://octopus.skylightnbs.com' | Octopus Deploy server URL. | false |
@@ -71,7 +71,8 @@ This workflow build a container and push it to ECR. Application versioning is ob
 #### Input Secrets
 | Key | Type | Default | Description | Required |
 | -------------- | -------------- | -------------- | -------------- | -------------- |
-| CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID | string |  | 'Secret named CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID where ECR resides.' | true |
+| NBS_ACCOUNTID | string | | 'AWS Account ID where ECR resides.' | false |
+| CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID | string |  | 'Backward compatible AWS Account ID where ECR resides.' | false |
 | ECR_REPO_BASE_NAME | string |  | 'Secret named ECR_REPO_BASE_NAME where ECR resides.' | true |
 | GIT_USER_EMAIL | string |  | 'Secret named GIT_USER_EMAIL for the CI user email.' | false |
 | GIT_USER_NAME | string |  | 'Secret named ECR_REPO_BASE_NAME for the CI user name.' | false |
@@ -83,7 +84,13 @@ This workflow build a container and push it to ECR. Application versioning is ob
 | output_image_tag | string | "Container image tag"  |
 
 #### Octopus Deploy Release Creation
-When `create_octopus_release` is enabled, a release is automatically created in Octopus Deploy after a successful ECR push. The Octopus API key is retrieved from AWS Secrets Manager using the same IAM role used for ECR — no additional GitHub secrets are required.
+When `create_octopus_release` is enabled (or when running on the `main` branch), a release is automatically created in Octopus Deploy after a successful ECR push. The workflow uses a centralized mapping file to resolve naming discrepancies and handle complex multi-service projects.
+
+**Features:**
+- **Automatic on Main:** Releases are automatically created on push to the `main` branch if the Octopus API key ARN is available.
+- **Centralized Mapping:** Uses [octopus-mapping.yaml](./octopus-mapping.yaml) to map `microservice_name` to the correct Octopus Project and Package ID. This allows for "zero-touch" integration in downstream repositories.
+- **Multi-Service Support:** For projects that deploy multiple services (e.g., Modernization stack), building one service will create a release that includes the new version for that service while automatically picking the latest available versions for its siblings.
+- **Flexible Secrets:** Supports both `NBS_ACCOUNTID` and `CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID` for AWS authentication.
 
 **Prerequisites:**
 - The `AWS_OCTOPUS_API_KEY_ARN` variable must be set at the org or repo level (or passed via `octopus_api_key_secret_name`).
@@ -98,15 +105,13 @@ jobs:
       microservice_name: my-service
       dockerfile_relative_path: Dockerfile
       environment_classifier: SNAPSHOT
-      create_octopus_release: true
-      octopus_project: 'My Octopus Project'   # must match the project name in Octopus exactly
-      # octopus_channel defaults to 'alpha-main'
-      # octopus_space defaults to 'Default'
     secrets:
       NBS_ACCOUNTID: ${{ secrets.NBS_ACCOUNTID }}
 ```
+*Note: If `my-service` is defined in `octopus-mapping.yaml`, no additional Octopus configuration is needed.*
 
 The release number in Octopus will match the ECR image tag (e.g. `1.0.0-SNAPSHOT.abc1234`), giving full traceability between the Octopus release, the container image, and the git commit.
+
 
 ### [Build-other-microservice-container.yaml](./workflows/Build-other-microservice-container.yaml)
 This workflow build a container and push it to ECR. Application versioning is obtained using from the dockerfile after the initial `FROM` block (e.g. `FROM elasticsearch:v1.0.0` results in `v1.0.0`). Uses [Trivy-Scanner](.github/actions/trivy-scanner/action.yaml) for container scanning.
@@ -126,11 +131,18 @@ This workflow build a container and push it to ECR. Application versioning is ob
 | timeout | string | '10m0s' | 'Scan timeout duration' | false |
 | trivyignores | string |  | 'Comma-separated list of relative paths in repository to one or more .trivyignore files, for usage see https://aquasecurity.github.io/trivy/v0.19.2/vulnerability/examples/filter/' | false |
 | upload-to-github-security-tab | boolean | true | 'Upload results to GitHub security tab?' | false |
+| create_octopus_release | boolean | false | Create an Octopus Deploy release after successfully pushing to ECR. If false, it will still default to true on the main branch if the Octopus API key ARN is available. | false |
+| octopus_project | string | | Octopus Deploy project name to create a release for. Defaults to `microservice_name` if not provided. | false |
+| octopus_channel | string | 'alpha-main' | Octopus Deploy release channel. | false |
+| octopus_space | string | 'Default' | Octopus Deploy space name. | false |
+| octopus_server_url | string | 'https://octopus.skylightnbs.com' | Octopus Deploy server URL. | false |
+| octopus_api_key_secret_name | string | | Name or ARN of the AWS Secrets Manager secret holding the Octopus Deploy API key. Defaults to the `AWS_OCTOPUS_API_KEY_ARN` org/repo variable if not provided. | false |
 
 #### Input Secrets
 | Key | Type | Default | Description | Required |
 | -------------- | -------------- | -------------- | -------------- | -------------- |
-| CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID | string |  | 'Secret named CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID where ECR resides.' | true |
+| NBS_ACCOUNTID | string | | 'AWS Account ID where ECR resides.' | false |
+| CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID | string |  | 'Backward compatible AWS Account ID where ECR resides.' | false |
 | ECR_REPO_BASE_NAME | string |  | 'Secret named ECR_REPO_BASE_NAME where ECR resides.' | true |
 | GIT_USER_EMAIL | string |  | 'Secret named GIT_USER_EMAIL for the CI user email.' | false |
 | GIT_USER_NAME | string |  | 'Secret named ECR_REPO_BASE_NAME for the CI user name.' | false |

--- a/octopus-mapping.yaml
+++ b/octopus-mapping.yaml
@@ -5,6 +5,7 @@ mappings:
   # Simple mappings (microservice_name: "Octopus Project Name")
   nbs-gateway: "nbs-gateway Microservice"
   data-ingestion-service: "Data Ingestion Microservice"
+  nbs7-dataingestion-service: "Data Ingestion Microservice"
   data-processing-service: "Data Processing Microservice"
   nbs7-page-builder-api: "Page Builder API"
   nnd-case-notification-service: "NNDSS Case Notifications"

--- a/octopus-mapping.yaml
+++ b/octopus-mapping.yaml
@@ -3,17 +3,11 @@
 
 mappings:
   # Simple mappings (microservice_name: "Octopus Project Name")
-  nbs-gateway: "nbs-gateway Microservice"
-  data-ingestion-service: "Data Ingestion Microservice"
   nbs7-dataingestion-service: "Data Ingestion Microservice"
-  data-processing-service: "Data Processing Microservice"
+  nbs7-data-processing-service: "Data Processing Microservice"
+  nbs7-liquibase: "Liquibase Service"
+  nbs7-nbs-gateway: "nbs-gateway Microservice"
   nbs7-page-builder-api: "Page Builder API"
-  nnd-case-notification-service: "NNDSS Case Notifications"
-  nnd-service: "NNDSS"
-  data-extraction-service: "NNDSS Case Notifications"
-  reporting-services: "Data Reporting"
-  data-access-service: "Data Access"
-  datacompare-service: "Data Compare"
 
   # Complex mappings for projects that deploy multiple services
   # If a service belongs to a multi-service project, define its project and specific package ID.

--- a/octopus-mapping.yaml
+++ b/octopus-mapping.yaml
@@ -1,0 +1,27 @@
+# This file maps GitHub microservice names to Octopus Deploy project names and package IDs.
+# It is used by reusable workflows to automatically determine Octopus deployment targets.
+
+mappings:
+  # Simple mappings (microservice_name: "Octopus Project Name")
+  nbs-gateway: "nbs-gateway Microservice"
+  data-ingestion-service: "Data Ingestion Microservice"
+  data-processing-service: "Data Processing Microservice"
+  nbs7-page-builder-api: "Page Builder API"
+  nnd-case-notification-service: "NNDSS Case Notifications"
+  nnd-service: "NNDSS"
+  data-extraction-service: "NNDSS Case Notifications"
+  reporting-services: "Data Reporting"
+  data-access-service: "Data Access"
+  datacompare-service: "Data Compare"
+
+  # Complex mappings for projects that deploy multiple services
+  # If a service belongs to a multi-service project, define its project and specific package ID.
+  nbs7-modernization-api:
+    project: "Elasticsearch_Modernization-Api_Nifi-efs Microservice Deployment"
+    package: "nbs7-modernization-api"
+  nbs7-elasticsearch:
+    project: "Elasticsearch_Modernization-Api_Nifi-efs Microservice Deployment"
+    package: "nbs7-elasticsearch"
+  nbs7-nifi:
+    project: "Elasticsearch_Modernization-Api_Nifi-efs Microservice Deployment"
+    package: "nbs7-nifi"

--- a/sample_templates/Sample-call-build-and-deploy-workflow.yaml
+++ b/sample_templates/Sample-call-build-and-deploy-workflow.yaml
@@ -26,10 +26,10 @@ jobs:
       microservice_name: <microservice_name>
       dockerfile_relative_path: <dockerfile_relative_path>
       environment_classifier: <environment_classifier>
-      update_helm_chart: <update_helm_chart> 
-      values_file_with_path: <values_file_with_path>
+      # create_octopus_release: true # Optional: defaults to true on 'main' branch
+      # octopus_project: '<octopus_project_name>' # Optional: defaults to <microservice_name>
     secrets:
-      CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
+      NBS_ACCOUNTID: ${{secrets.NBS_ACCOUNTID}}
       ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}
       GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
       GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}


### PR DESCRIPTION
This PR adds new steps to the build / push workflow for that will create releases in octopus in the alpha-main release channel on matching products.

Sample build run: https://github.com/CDCgov/NEDSS-DataIngestion/actions/runs/26766900172

