### PR TITLE
Push container images to Harbor

### DIFF
--- a/.github/workflows/Build-gradle-microservice-container.yaml
+++ b/.github/workflows/Build-gradle-microservice-container.yaml
@@ -69,6 +69,12 @@ on:
       NBS_ACCOUNTID:
         description: "Secret named NBS_ACCOUNTID where ECR resides."
         required: true
+      harbor_robot_username:
+        description: "Account name for the Harbor robot account assigned to GitHub Actions"
+        required: true
+      harbor_robot_secret:
+        description: "Unique authentication secret for the Harbor robot account assigned to GitHub Actions"
+        required: true
     outputs:
       output_image_tag:
         description: "Container image tag" 
@@ -129,16 +135,26 @@ jobs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v2
 
+    - name: Log in to Harbor
+      id: log-in-harbor
+      uses: docker/login-action@v4
+      with:
+        registry: ${{ vars.harbor_url }}
+        username: ${{ secrets.harbor_robot_username }}
+        password: ${{ secrets.harbor_robot_secret }}
+
     - name: Build and tag ${{ inputs.microservice_name }} image
       id: build-image
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         ECR_REPOSITORY: ${{ inputs.microservice_name }}
+        HARBOR_REGISTRY: ${{ vars.harbor_url }}
+        HARBOR_REPOSITORY: ${{ inputs.microservice_name }}
         IMAGE_TAG: "${{ env.new_image_tag }}"
       run: |
         # Build a docker container 
         echo "Building image.." 
-        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG ${{ inputs.dockerfile_relative_path}}
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $HARBOR_REGISTRY/$HARBOR_REPOSITORY:$IMAGE_TAG ${{ inputs.dockerfile_relative_path}}
         echo "CONTAINER_TAG=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_ENV        
 
     - name: Scan container image
@@ -166,3 +182,15 @@ jobs:
         echo "Pushing image to ECR..."
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+    - name: Push ${{ inputs.microservice_name }} image to Harbor
+      if: ${{ !cancelled() }}
+      id: push-image-harbor
+      env:
+        HARBOR_REGISTRY: ${{ vars.harbor_url }}
+        HARBOR_REPOSITORY: ${{ inputs.microservice_name }}
+        IMAGE_TAG: "${{ env.new_image_tag }}"
+      run: |
+        echo "Pushing image to ECR..."
+        docker push $HARBOR_REGISTRY/$HARBOR_REPOSITORY:$IMAGE_TAG
+        echo "harbor_image=$HARBOR_REGISTRY/$HARBOR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT

--- a/.github/workflows/Build-gradle-microservice-container.yaml
+++ b/.github/workflows/Build-gradle-microservice-container.yaml
@@ -224,7 +224,7 @@ jobs:
         HARBOR_REPOSITORY: ${{ inputs.microservice_name }}
         IMAGE_TAG: "${{ env.new_image_tag }}"
       run: |
-        echo "Pushing image to ECR..."
+        echo "Pushing image to Harbor..."
         docker push $HARBOR_REGISTRY/$HARBOR_REPOSITORY:$IMAGE_TAG
         echo "harbor_image=$HARBOR_REGISTRY/$HARBOR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
   

--- a/.github/workflows/Build-gradle-microservice-container.yaml
+++ b/.github/workflows/Build-gradle-microservice-container.yaml
@@ -99,10 +99,10 @@ on:
       NBS_ACCOUNTID:
         description: "AWS Account ID where ECR resides."
         required: false
-      harbor_robot_username:
+      HARBOR_ROBOT_USERNAME:
         description: "Account name for the Harbor robot account assigned to GitHub Actions"
         required: true
-      harbor_robot_secret:
+      HARBOR_ROBOT_SECRET:
         description: "Unique authentication secret for the Harbor robot account assigned to GitHub Actions"
         required: true
       CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID:
@@ -173,8 +173,8 @@ jobs:
       uses: docker/login-action@v4
       with:
         registry: ${{ vars.harbor_url }}
-        username: ${{ secrets.harbor_robot_username }}
-        password: ${{ secrets.harbor_robot_secret }}
+        username: ${{ secrets.HARBOR_ROBOT_USERNAME }}
+        password: ${{ secrets.HARBOR_ROBOT_SECRET }}
 
     - name: Build and tag ${{ inputs.microservice_name }} image
       id: build-image

--- a/.github/workflows/Build-other-microservice-container.yaml
+++ b/.github/workflows/Build-other-microservice-container.yaml
@@ -94,10 +94,10 @@ on:
       NBS_ACCOUNTID:
         description: "AWS Account ID where ECR resides."
         required: false
-      harbor_robot_username:
+      HARBOR_ROBOT_USERNAME:
         description: "Account name for the Harbor robot account assigned to GitHub Actions"
         required: true
-      harbor_robot_secret:
+      HARBOR_ROBOT_SECRET:
         description: "Unique authentication secret for the Harbor robot account assigned to GitHub Actions"
         required: true
       CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID:
@@ -162,8 +162,8 @@ jobs:
       uses: docker/login-action@v4
       with:
         registry: ${{ vars.harbor_url }}
-        username: ${{ secrets.harbor_robot_username }}
-        password: ${{ secrets.harbor_robot_secret }}
+        username: ${{ secrets.HARBOR_ROBOT_USERNAME }}
+        password: ${{ secrets.HARBOR_ROBOT_SECRET }}
 
     - name: Build and tag ${{ inputs.microservice_name }} image 
       id: build-image

--- a/.github/workflows/Build-other-microservice-container.yaml
+++ b/.github/workflows/Build-other-microservice-container.yaml
@@ -64,6 +64,12 @@ on:
       NBS_ACCOUNTID:
         description: "Secret named NBS_ACCOUNTID where ECR resides."
         required: true
+      harbor_robot_username:
+        description: "Account name for the Harbor robot account assigned to GitHub Actions"
+        required: true
+      harbor_robot_secret:
+        description: "Unique authentication secret for the Harbor robot account assigned to GitHub Actions"
+        required: true
     outputs:
       output_image_tag:
         description: "Container image tag" 
@@ -118,16 +124,26 @@ jobs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v2
 
+    - name: Log in to Harbor
+      id: log-in-harbor
+      uses: docker/login-action@v4
+      with:
+        registry: ${{ vars.harbor_url }}
+        username: ${{ secrets.harbor_robot_username }}
+        password: ${{ secrets.harbor_robot_secret }}
+
     - name: Build and tag ${{ inputs.microservice_name }} image 
       id: build-image
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         ECR_REPOSITORY: ${{ inputs.microservice_name }}
+        HARBOR_REGISTRY: ${{ vars.harbor_url }}
+        HARBOR_REPOSITORY: ${{ inputs.microservice_name }}
         IMAGE_TAG: "${{ env.new_image_tag }}"
       run: |
         # Build a docker container
         echo "Building image.." 
-        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG ${{ inputs.dockerfile_relative_path}}
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $HARBOR_REGISTRY/$HARBOR_REPOSITORY:$IMAGE_TAG ${{ inputs.dockerfile_relative_path}}
         echo "CONTAINER_TAG=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_ENV
       
     - name: Scan container image 
@@ -155,4 +171,16 @@ jobs:
         echo "Pushing image to ECR..."
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+    - name: Push ${{ inputs.microservice_name }} image to Harbor
+      if: ${{ !cancelled() }}
+      id: push-image-harbor
+      env:
+        HARBOR_REGISTRY: ${{ vars.harbor_url }}
+        HARBOR_REPOSITORY: ${{ inputs.microservice_name }}
+        IMAGE_TAG: "${{ env.new_image_tag }}"
+      run: |
+        echo "Pushing image to ECR..."
+        docker push $HARBOR_REGISTRY/$HARBOR_REPOSITORY:$IMAGE_TAG
+        echo "harbor_image=$HARBOR_REGISTRY/$HARBOR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/Build-other-microservice-container.yaml
+++ b/.github/workflows/Build-other-microservice-container.yaml
@@ -213,7 +213,7 @@ jobs:
         HARBOR_REPOSITORY: ${{ inputs.microservice_name }}
         IMAGE_TAG: "${{ env.new_image_tag }}"
       run: |
-        echo "Pushing image to ECR..."
+        echo "Pushing image to Harbor..."
         docker push $HARBOR_REGISTRY/$HARBOR_REPOSITORY:$IMAGE_TAG
         echo "harbor_image=$HARBOR_REGISTRY/$HARBOR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
This PR expands existing container build and push workflows to use Harbor as an additional push site, in addition to the existing ECR site.

Tags and pushes will take place to both artifact repositories for the time being, with plans to slowly make a complete transition from ECR to Harbor.